### PR TITLE
New filters

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -7166,6 +7166,11 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.3.1.tgz",
       "integrity": "sha512-adQOIzh+bfdridLM1xIgJ9VnJbAUY3wqs/ueF+ITla+PLQ1z47USdBKUf+iD9FuUA8RtlT6j6hZBfZoA6mW+XQ=="
     },
+    "leaflet-draw": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.2.tgz",
+      "integrity": "sha512-iCcbXE9okhwznoTXjxVjoGFoKeiWGsgmWPKrPAeHUvtWZWK4t6YF6815D13wZoMxX2UM6tOmD7/VofCxx3S0+w=="
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -4578,6 +4578,11 @@
         "pend": "1.2.0"
       }
     },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -13308,6 +13313,14 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
       "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==",
       "dev": true
+    },
+    "vue2-datepicker": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-2.0.4.tgz",
+      "integrity": "sha512-24yKv1S/J+K0GHV+DCYpP8U8GXE4lf0hnsSoRrss+pXUBqLdGdUPTU7sYU9z3esHmkMclDN9uRwJDhxcIQ+3BA==",
+      "requires": {
+        "fecha": "2.3.3"
+      }
     },
     "vuex": {
       "version": "3.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -22,6 +22,7 @@
     "qs": "^6.5.2",
     "vue": "^2.5.2",
     "vue-router": "^3.0.1",
+    "vue2-datepicker": "^2.0.4",
     "vuex": "^3.0.1"
   },
   "devDependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
     "bootstrap": "^4.1.1",
     "jquery": "^3.3.1",
     "leaflet": "^1.3.1",
+    "leaflet-draw": "^1.0.2",
     "popper.js": "^1.14.3",
     "qs": "^6.5.2",
     "vue": "^2.5.2",

--- a/app/src/Grout.js
+++ b/app/src/Grout.js
@@ -380,7 +380,7 @@ class Record extends AbstractApiClass {
                         data.occurred_min = filter.from;
                     }
                     if (filter.to) {
-                        data.occurred_to = filter.to;
+                        data.occurred_max = filter.to;
                     }
                     if (filter.polygon) {
                         // Polygons should be passed in as GeoJSON objects.

--- a/app/src/Grout.js
+++ b/app/src/Grout.js
@@ -370,8 +370,9 @@ class Record extends AbstractApiClass {
 
             filters.forEach(filter => {
                 // Validate that the filter is formatted appropriately.
-                // First, check the pre-defined filters (type and date/time).
-                if (filter.type || filter.from || filter.to) {
+                // First, check the pre-defined filters (type, date/time, and
+                // polygon).
+                if (filter.type || filter.from || filter.to || filter.polygon) {
                     if (filter.type) {
                         data.record_type = filter.type;
                     }
@@ -380,6 +381,10 @@ class Record extends AbstractApiClass {
                     }
                     if (filter.to) {
                         data.occurred_to = filter.to;
+                    }
+                    if (filter.polygon) {
+                        // Polygons should be passed in as GeoJSON objects.
+                        data.polygon = JSON.stringify(filter.polygon);
                     }
                 } else {
                     // Dynamic query -- build the nested query structure.

--- a/app/src/components/Filters.vue
+++ b/app/src/components/Filters.vue
@@ -18,6 +18,9 @@
                 {{ type.label }}
             </option>
         </select>
+        <div class="my-2">
+            <datetime-picker/>
+        </div>
         <filter-container :filters="filters"/>
     </form>
 </template>
@@ -26,6 +29,7 @@
 import { mapState } from 'vuex';
 
 import Grout from '@/api';
+import Datetime from './filters/Datetime';
 import FilterContainer from './filters/Container';
 
 
@@ -33,6 +37,7 @@ export default {
     name: 'FliersFilters',
     components: {
         'filter-container': FilterContainer,
+        'datetime-picker': Datetime,
     },
     data() {
         return {

--- a/app/src/components/Map.vue
+++ b/app/src/components/Map.vue
@@ -107,6 +107,13 @@ export default {
                 this.$store.commit('updatePolygon', event.layer.toGeoJSON().geometry);
                 this.$store.dispatch('updateRecords');
             });
+
+            // When a user deletes a geometry, rerun queries.
+            this.map.on('draw:deleted', event => {
+                // Update Records.
+                this.$store.commit('updatePolygon', {});
+                this.$store.dispatch('updateRecords');
+            })
         },
 
         initTiles() {

--- a/app/src/components/filters/Datetime.vue
+++ b/app/src/components/filters/Datetime.vue
@@ -1,0 +1,51 @@
+<template>
+    <div>
+        <date-picker
+            v-model="dateRange"
+            range
+            width="inherit"
+            placeholder="Filter by date range"
+            lang="en"
+            @change="updateDateRange"
+        />
+    </div>
+</template>
+
+<script>
+import DatePicker from 'vue2-datepicker';
+
+export default {
+    components: {
+        'date-picker': DatePicker,
+    },
+    data() {
+        return {
+            dateRange: [null, null],  // Data bound to the user's input.
+        }
+    },
+    computed: {
+        minDate: function() {
+            // The minimum date in the date range.
+            return this.dateRange[0];
+        },
+        maxDate: function() {
+            // The maximum date in the date range.
+            return this.dateRange[1];
+        }
+    },
+    methods: {
+        updateDateRange() {
+            /*
+             * Update the date range filters in the data store, and then query
+             * for matching Records.
+             */
+            // Update minimum and maximum dates.
+            this.$store.commit('updateMinDate', this.minDate);
+            this.$store.commit('updateMaxDate', this.maxDate);
+
+            // Rereun the Records query.
+            this.$store.dispatch('updateRecords');
+        }
+    }
+}
+</script>

--- a/app/src/store.js
+++ b/app/src/store.js
@@ -227,7 +227,7 @@ const filterState = {
             }
 
             // Add any other filters that are defined in the filter state.
-            queryParams.concat(context.state.filters);
+            queryParams = queryParams.concat(context.state.filters);
 
             return new Promise((resolve, reject) => {
                 Grout.records.query(...queryParams)

--- a/app/src/store.js
+++ b/app/src/store.js
@@ -18,6 +18,7 @@ const filterState = {
         filters: [],  // Array of currently selected filters.
         from: '',  // Minimum date for Records.
         to: '',  // Maximum date for Records.
+        polygon: {},  // Geometry for filtering records (GeoJSON).
     },
     mutations: {
 
@@ -73,6 +74,16 @@ const filterState = {
              *                        as YYY:MM:DDTHH:mm:ss.SSS
              */
             state.to = to;
+        },
+
+        updatePolygon(state, geojson) {
+            /*
+             * Set the value for the geometry to use to filter records.
+             *
+             * @param {Object} geojson - The GeoJSON object to use for
+             *                           filtering.
+             */
+            state.polygon = geojson;
         },
 
         updateFilter(state, filter) {
@@ -210,6 +221,9 @@ const filterState = {
             }
             if (context.state.to) {
                 queryParams.push({to: context.state.to});
+            }
+            if (Object.keys(context.state.polygon).length > 0) {
+                queryParams.push({polygon: context.state.polygon})
             }
 
             // Add any other filters that are defined in the filter state.


### PR DESCRIPTION
# Overview

Adds new filters for datetime ranges and polygon boundaries.

## Demo

Filtering by date:

![date-filter](https://user-images.githubusercontent.com/14170650/43471341-c0e3ee6c-94b8-11e8-87aa-23628d8a8349.png)

Filtering by polygon:

![filter-polygon](https://user-images.githubusercontent.com/14170650/43471354-ca62e2cc-94b8-11e8-81e0-67edb37884d4.png)

## Testing instructions

The frontend doesn't have tests yet. To test the new filters, you'll have to run the server and play around with them:

```bash
# Build containers and install NPM modules.
./scripts/update

# Run the dev server.
./scripts/server
```

Travis will run unit tests for the schema editor and Grout server to confirm that there are no regressions in those apps. If you'd like to run those tests yourself, you can use the `test` script:

```bash
./scripts/test
```

